### PR TITLE
캘린더 Modal창 구현

### DIFF
--- a/myWebPage/client/src/Components/CalendarPage/ModalTodoItem.tsx
+++ b/myWebPage/client/src/Components/CalendarPage/ModalTodoItem.tsx
@@ -1,36 +1,44 @@
-import React, { useState } from "react";
+import React from "react";
+import styled from "styled-components";
 import { ModalTList } from "./ModalTodoList";
-
 
 interface ModalItemProps {
     key: number;
+    id: number;
     text: string;
     completed: boolean;
-    onClickCompletedUpdate(updateModalTodoItem: ModalTList): void;
+    onClickCompleted(updateModalTodoItem: ModalTList): void;
 }
 
 export default function ModalTodoItem({
     key,
+    id,
     text,
     completed,
-    onClickCompletedUpdate }: ModalItemProps) {
+    onClickCompleted }: ModalItemProps) {
+
+    const ListItem = styled.li`
+            list-style: none;
+            display: flex;
+        `
 
     // 완료 버튼 클릭 함수
-    const handleComplete = () => {
-        const updateModalTodoItem = {
+    const handleCompleted = () => {
+        const updatedItem = {
             key: key,
+            id: id,
             text: text,
-            completed: !completed
+            completed: !completed,
         }
-        onClickCompletedUpdate(updateModalTodoItem);
+        onClickCompleted(updatedItem);
     }
 
     return (
-        <div key={key}>
-            <button className="Button_complete" onClick={handleComplete}>
-                {completed ? "✅" : "  "}
+        <ListItem>
+            <button className="Button_complete" onClick={handleCompleted}>
+                {completed ? "✅" : " "}
             </button>
             <p style={completed ? { textDecoration: "line-through" } : undefined}> {text}</p>
-        </div>
+        </ListItem>
     )
 }

--- a/myWebPage/client/src/Components/CalendarPage/ModalTodoList.tsx
+++ b/myWebPage/client/src/Components/CalendarPage/ModalTodoList.tsx
@@ -4,6 +4,7 @@ import ModalTodoItem from "./ModalTodoItem";
 // 초기 틀 설정
 export interface ModalTList {
     key: number;
+    id: number;
     text: string;
     completed: boolean;
 }
@@ -13,42 +14,46 @@ export default function ModalTodoList() {
     const [modalTodoList, setModalTodoList] = useState<ModalTList[]>([
         {
             key: 1,
+            id: 1,
             text: '아르바이트',
             completed: false,
         },
         {
             key: 2,
+            id: 2,
             text: '청소',
             completed: false,
         }, {
             key: 3,
+            id: 3,
             text: '운동',
             completed: false,
         }
     ]);
 
     // modalTodoItem.tsx에서 전달 받은 인수 처리함수
-    const textUpdatedHandler = (newModalTodoItem: ModalTList): void => {
-        const newModalTodoList = modalTodoList.map((item) => {
-            if (item.key === newModalTodoItem.key) {
-                return newModalTodoItem;
+    const textUpdatedHandler = (newModalItem: ModalTList): void => {
+        const newItem = modalTodoList.map((item) => {
+            if (item.id === newModalItem.id) {
+                return newModalItem;
             } else {
                 return item;
             }
         })
-        setModalTodoList(newModalTodoList)
+        setModalTodoList(newItem);
     }
 
     return (
-        <>
+        <div>
             {modalTodoList.map((item) => (
                 <ModalTodoItem
                     key={item.key}
+                    id={item.id}
                     text={item.text}
                     completed={item.completed}
-                    onClickCompletedUpdate={textUpdatedHandler} />
+                    onClickCompleted={textUpdatedHandler} />
             ))
             }
-        </>
+        </div>
     )
 }

--- a/myWebPage/client/src/styles/ModalTodo.css
+++ b/myWebPage/client/src/styles/ModalTodo.css
@@ -18,5 +18,6 @@
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
     min-width: 300px;
     max-width: 90vw;
+    
   }
   


### PR DESCRIPTION
# 목표
* 모달창 클릭 시 해당 날짜에 맞는 데이터 불러오기
* 리스트가 3개 이상일 경우 더보기 버튼 활성화 -> 확장해서 보여주고 접기 버튼 활성화 -> 다시 간략화
* 달력에서 보여주는 리스트는 간략하게 -> (완료 / 미완료) 버튼만 활성화 - 완료
* 확장 아이콘 클릭시 메인화면으로 이동 - 완료
* 전체적인 스타일 다듬기 (확장형 아이콘 클릭시 애니메이션효과)